### PR TITLE
fix: return eligible assigned scenario falsy values

### DIFF
--- a/packages/graphql-kimera/src/__test__/mockProviders.test.js
+++ b/packages/graphql-kimera/src/__test__/mockProviders.test.js
@@ -71,6 +71,12 @@ describe('mergeScenarios', () => {
 
     expect(actual).toBe(false);
   });
+
+  it('handle scenario with value of _""_', () => {
+    const actual = mergeScenarios(undefined, '');
+
+    expect(actual).toBe('');
+  });
 });
 
 describe('mergeBuilders', () => {

--- a/packages/graphql-kimera/src/__test__/mockProviders.test.js
+++ b/packages/graphql-kimera/src/__test__/mockProviders.test.js
@@ -59,6 +59,18 @@ describe('mergeScenarios', () => {
 
     expect(actual.me.userName).toBe('c10b10');
   });
+
+  it('handle scenario with value of _0_', () => {
+    const actual = mergeScenarios(undefined, 0);
+
+    expect(actual).toBe(0);
+  });
+
+  it('handle scenario with value of _false_', () => {
+    const actual = mergeScenarios(undefined, false);
+
+    expect(actual).toBe(false);
+  });
 });
 
 describe('mergeBuilders', () => {

--- a/packages/graphql-kimera/src/mockProviders.js
+++ b/packages/graphql-kimera/src/mockProviders.js
@@ -53,14 +53,7 @@ const isResolverScenario = (node) => {
 const mergeScenarios = memoize(
   (baseScenario, assignedScenario, meta) => {
     if (isUndefined(assignedScenario) || isUndefined(baseScenario)) {
-      if (
-        assignedScenario ||
-        assignedScenario === 0 ||
-        typeof assignedScenario === 'boolean'
-      ) {
-        return assignedScenario;
-      }
-      return baseScenario;
+      return !isUndefined(assignedScenario) ? assignedScenario : baseScenario;
     }
 
     if (isNull(assignedScenario) || isNull(baseScenario)) {

--- a/packages/graphql-kimera/src/mockProviders.js
+++ b/packages/graphql-kimera/src/mockProviders.js
@@ -53,7 +53,14 @@ const isResolverScenario = (node) => {
 const mergeScenarios = memoize(
   (baseScenario, assignedScenario, meta) => {
     if (isUndefined(assignedScenario) || isUndefined(baseScenario)) {
-      return assignedScenario || baseScenario;
+      if (
+        assignedScenario ||
+        assignedScenario === 0 ||
+        typeof assignedScenario === 'boolean'
+      ) {
+        return assignedScenario;
+      }
+      return baseScenario;
     }
 
     if (isNull(assignedScenario) || isNull(baseScenario)) {


### PR DESCRIPTION
Return the eligible falsy assigned scenario values

This PR should fix this [issue](https://github.com/lola-tech/graphql-kimera/issues/70)