### PR TITLE
fix: Move graphql lib to peerDependecies

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,11 +24,13 @@ jobs:
         uses: actions/setup-node@v1.4.2
         with:
           node-version: ${{ matrix.node-version }}
-      
+
       - run: npm install
-      
+
+      - run: npm install graphql@14
+
       - run: npm test
-      
+
       # Coveralls Test coverage reports -- to be enabled after we get access to lola-tech org
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v1.1.1

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera graphql
+npm install --save-dev @lola-tech/graphql-kimera graphql@14
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera graphql
+yarn add --dev @lola-tech/graphql-kimera graphql@14
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera
+npm install --save-dev @lola-tech/graphql-kimera graphql
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera
+yarn add --dev @lola-tech/graphql-kimera graphql
 ```
 
 ### Examples

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,9 @@
   "packages": ["packages/*"],
   "version": "independent",
   "command": {
+    "version": {
+      "allowBranch": "master"
+    },
     "noPrivate": true
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,9 +2,6 @@
   "packages": ["packages/*"],
   "version": "independent",
   "command": {
-    "version": {
-      "allowBranch": "master"
-    },
     "noPrivate": true
   }
 }

--- a/packages/graphql-kimera-docs/CHANGELOG.md
+++ b/packages/graphql-kimera-docs/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.1](https://github.com/lola-tech/graphql-kimera/compare/@lola-tech/graphql-kimera-docs@0.11.0...@lola-tech/graphql-kimera-docs@0.11.1) (2020-06-29)
+
+
+### Bug Fixes
+
+* move graphql to peerDeps - fixes [#77](https://github.com/lola-tech/graphql-kimera/issues/77) ([3cf61fe](https://github.com/lola-tech/graphql-kimera/commit/3cf61fea5875d2962d66d6451a71fb8f19dc0cb2))
+
+
+
+
+
 # [0.11.0](https://github.com/lola-tech/graphql-kimera/compare/@lola-tech/graphql-kimera-docs@0.10.1...@lola-tech/graphql-kimera-docs@0.11.0) (2020-05-29)
 
 

--- a/packages/graphql-kimera-docs/README.md
+++ b/packages/graphql-kimera-docs/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera graphql
+npm install --save-dev @lola-tech/graphql-kimera graphql@14
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera graphql
+yarn add --dev @lola-tech/graphql-kimera graphql@14
 ```
 
 ### Examples

--- a/packages/graphql-kimera-docs/README.md
+++ b/packages/graphql-kimera-docs/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera
+npm install --save-dev @lola-tech/graphql-kimera graphql
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera
+yarn add --dev @lola-tech/graphql-kimera graphql
 ```
 
 ### Examples

--- a/packages/graphql-kimera-docs/docs/setup.md
+++ b/packages/graphql-kimera-docs/docs/setup.md
@@ -15,13 +15,13 @@ This page walks you through the steps you need to take in order to get a Kimera 
 To install Kimera you can install it via npm or yarn, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```sh
-npm install --save-dev @lola-tech/graphql-kimera
+npm install --save-dev @lola-tech/graphql-kimera graphql
 ```
 
 or if you want to use yarn
 
 ```sh
-yarn add --dev @lola-tech/graphql-kimera
+yarn add --dev @lola-tech/graphql-kimera graphql
 ```
 
 ### Using Kimera
@@ -31,8 +31,8 @@ To use Kimera, you'll need a GraphQL server, and the schema definitions.
 We'll use Apollo Server for the server, but any GraphQL server would work. See [how to install Apollo Server in the Apollo docs](https://www.apollographql.com/docs/apollo-server/getting-started/#step-2-install-dependencies).
 
 ```javascript title="server.js" {2,26,29}
-const { ApolloServer, gql } = require("apollo-server");
-const { getExecutableSchema } = require("@lola-tech/graphql-kimera");
+const { ApolloServer, gql } = require('apollo-server');
+const { getExecutableSchema } = require('@lola-tech/graphql-kimera');
 
 const schema = gql`
   type User {

--- a/packages/graphql-kimera-docs/docs/setup.md
+++ b/packages/graphql-kimera-docs/docs/setup.md
@@ -15,13 +15,13 @@ This page walks you through the steps you need to take in order to get a Kimera 
 To install Kimera you can install it via npm or yarn, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```sh
-npm install --save-dev @lola-tech/graphql-kimera graphql
+npm install --save-dev @lola-tech/graphql-kimera graphql@14
 ```
 
 or if you want to use yarn
 
 ```sh
-yarn add --dev @lola-tech/graphql-kimera graphql
+yarn add --dev @lola-tech/graphql-kimera graphql@14
 ```
 
 ### Using Kimera

--- a/packages/graphql-kimera-docs/package-lock.json
+++ b/packages/graphql-kimera-docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lola-tech/graphql-kimera-docs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/graphql-kimera-docs/package.json
+++ b/packages/graphql-kimera-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lola-tech/graphql-kimera-docs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "The documentation for Kimera.",
   "main": "index.js",
   "private": true,

--- a/packages/graphql-kimera/CHANGELOG.md
+++ b/packages/graphql-kimera/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.10.0-alpha.9](https://github.com/lola-tech/graphql-kimera/compare/@lola-tech/graphql-kimera@0.10.0-alpha.8...@lola-tech/graphql-kimera@0.10.0-alpha.9) (2020-06-29)
+
+
+### Bug Fixes
+
+* move graphql to peerDeps - fixes [#77](https://github.com/lola-tech/graphql-kimera/issues/77) ([3cf61fe](https://github.com/lola-tech/graphql-kimera/commit/3cf61fea5875d2962d66d6451a71fb8f19dc0cb2))
+
+
+
+
+
 # [0.10.0-alpha.8](https://github.com/lola-tech/graphql-kimera/compare/@lola-tech/graphql-kimera@0.10.0-alpha.7...@lola-tech/graphql-kimera@0.10.0-alpha.8) (2020-06-16)
 
 

--- a/packages/graphql-kimera/README.md
+++ b/packages/graphql-kimera/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera graphql
+npm install --save-dev @lola-tech/graphql-kimera graphql@14
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera graphql
+yarn add --dev @lola-tech/graphql-kimera graphql@14
 ```
 
 ### Examples

--- a/packages/graphql-kimera/README.md
+++ b/packages/graphql-kimera/README.md
@@ -29,13 +29,13 @@ Kimera is useful to:
 To install Kimera you can install it via `npm` or `yarn`, it's totally up to you. We're guessing that you'll most likely want Kimera to be a dev dependency.
 
 ```
-npm install --save-dev @lola-tech/graphql-kimera
+npm install --save-dev @lola-tech/graphql-kimera graphql
 ```
 
 or if you want to use yarn
 
 ```
-yarn add --dev @lola-tech/graphql-kimera
+yarn add --dev @lola-tech/graphql-kimera graphql
 ```
 
 ### Examples

--- a/packages/graphql-kimera/package-lock.json
+++ b/packages/graphql-kimera/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lola-tech/graphql-kimera",
-  "version": "0.10.0-alpha.8",
+  "version": "0.10.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/graphql-kimera/package.json
+++ b/packages/graphql-kimera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lola-tech/graphql-kimera",
-  "version": "0.10.0-alpha.8",
+  "version": "0.10.0-alpha.9",
   "description": "Kimera is a library for mocking GraphQL servers with precision.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/graphql-kimera/package.json
+++ b/packages/graphql-kimera/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "easygraphql-parser": "0.0.12",
-    "graphql": "14.1.1",
     "graphql-tools": "4.0.5",
     "lodash": "4.17.13",
     "multikeymap": "^1.0.0"
@@ -18,6 +17,9 @@
     "apollo-server-testing": "^2.14.1",
     "immutability-helper": "3.0.2",
     "jest": "24.8.0"
+  },
+  "peerDependencies": {
+    "graphql": ">=14.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should fix #77 by moving the `graphql` package to `peerDependecies` and asking the consumer to install the version they use. 

It's the approach taken by [Apollo Client](https://www.apollographql.com/docs/react/get-started/#installation), and other libraries that consume `graphql`.